### PR TITLE
Performance fixes

### DIFF
--- a/examples/Images/images.php
+++ b/examples/Images/images.php
@@ -29,7 +29,7 @@ div.floatright,table.floatright,div.floatleft,table.floatleft {
 
     <?php
     # Version of SimpleTest to open in a web-browser
-    $input = file_get_contents("input.txt");
+    $input = file_get_contents(__DIR__ . "/input.txt");
 
     $parser = new WikitextParser($input);
     echo $parser -> result;

--- a/examples/SimpleTest/SimpleTest-web.php
+++ b/examples/SimpleTest/SimpleTest-web.php
@@ -3,7 +3,7 @@
 require_once(__DIR__ . "/../../vendor/autoload.php");
 use Mike42\Wikitext\WikitextParser;
 
-$input = file_get_contents("input.txt");
+$input = file_get_contents(__DIR__ . "/input.txt");
 
 $parser = new WikitextParser($input);
 echo $parser -> result;

--- a/examples/SimpleTest/SimpleTest.php
+++ b/examples/SimpleTest/SimpleTest.php
@@ -3,11 +3,11 @@
 require_once(__DIR__ . "/../../vendor/autoload.php");
 use Mike42\Wikitext\WikitextParser;
 
-$input = file_get_contents("input.txt");
+$input = file_get_contents(__DIR__ . "/input.txt");
 
 /* The most rudimentary way to invoke the parser */
 $parser = new WikitextParser($input);
 $output = $parser -> result;
 
-file_put_contents("output.html", $output);
+file_put_contents(__DIR__ . "/output.html", $output);
 ?>

--- a/examples/SimpleTest/output.html
+++ b/examples/SimpleTest/output.html
@@ -1,7 +1,7 @@
 <p>Lorem <b>ipsum dolor</b> sit amet, consectetur (<i>adipisicing elit</i>), sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 <p>Ut enim ad minim veniam, quis nostrud <b><i>exercitation</i></b> ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
 <p>words written on separate lines will not be separated by line breaks</p>
-<p><a href="http://en.wikipedia.org/wiki/Example" title="wikipedia:Example">wikipedia:Example</a> &mdash; interwiki link.</p>
+<p><a href="https://en.wikipedia.org/wiki/Example" title="wikipedia:Example">wikipedia:Example</a> &mdash; interwiki link.</p>
 <h2>Section</h2>
 <p>Information contained in this section.</p>
 <ul>

--- a/src/Mike42/Wikitext/ParserInlineElement.php
+++ b/src/Mike42/Wikitext/ParserInlineElement.php
@@ -13,13 +13,13 @@ class ParserInlineElement
     public $argNameSep;
     public $hasArgs;
     
-    public function __construct($startTag, $endTag, $argSep = '', $argNameSep = '', $argLimit = 0)
+    public function __construct(string $startTag, string $endTag, string $argSep = '', string $argNameSep = '', int $argLimit = 0)
     {
-        $this -> startTag = $startTag;
-        $this -> endTag = $endTag;
-        $this -> argSep = $argSep;
-        $this -> argNameSep = $argNameSep;
+        $this -> startTag = str_split($startTag);
+        $this -> endTag = str_split($endTag);
+        $this -> argSep = str_split($argSep);
+        $this -> argNameSep = str_split($argNameSep);
         $this -> argLimit = $argLimit;
-        $this -> hasArgs = $this -> argSep != '';
+        $this -> hasArgs = count($this -> argSep) > 0;
     }
 }

--- a/src/Mike42/Wikitext/ParserTableElement.php
+++ b/src/Mike42/Wikitext/ParserTableElement.php
@@ -9,11 +9,11 @@ class ParserTableElement
     public $limit;
     public $inlinesep;
 
-    public function __construct($lineStart, $argsep, $inlinesep, $limit)
+    public function __construct(string $lineStart, string $argsep, string $inlinesep, $limit)
     {
-        $this -> lineStart = $lineStart;
-        $this -> argsep = $argsep;
-        $this -> inlinesep = $inlinesep;
+        $this -> lineStart = str_split($lineStart);
+        $this -> argsep = str_split($argsep);
+        $this -> inlinesep = str_split($inlinesep);
         $this -> limit = $limit;
     }
 }

--- a/src/Mike42/Wikitext/WikitextParser.php
+++ b/src/Mike42/Wikitext/WikitextParser.php
@@ -109,7 +109,8 @@ class WikitextParser
         self::$initialised = true;
     }
 
-    private static function elementLookupTable(array $elements) {
+    private static function elementLookupTable(array $elements)
+    {
         $lookup = [];
         foreach ($elements as $key => $token) {
             if (count($token -> startTag) != 0) {
@@ -146,7 +147,7 @@ class WikitextParser
             self::init();
         }
         $this -> params = $params;
-        $this -> preprocessed = $this -> preprocessText(self::explode_string($text));
+        $this -> preprocessed = $this -> preprocessText(self::explodeString($text));
 
         /* Now divide into paragraphs */
         // TODO operate on arrays instead of strings here
@@ -155,7 +156,7 @@ class WikitextParser
         $newtext = [];
         foreach ($sections as $section) {
             /* Newlines at the start/end have special meaning (compare to how this is called from parseLineBlock) */
-            $sectionChars = self::explode_string("\n".$section);
+            $sectionChars = self::explodeString("\n".$section);
             $result = $this -> parseInline($sectionChars, 'p');
             $newtext[] = $result['parsed'];
         }
@@ -163,7 +164,8 @@ class WikitextParser
         $this -> result = implode($newtext);
     }
 
-    private static function explode_string(string $string) {
+    private static function explodeString(string $string)
+    {
         return $chrArray = preg_split('//u', $string, -1, PREG_SPLIT_NO_EMPTY);
     }
 
@@ -181,7 +183,7 @@ class WikitextParser
         for ($i = 0; $i < $len; $i++) {
             $hit = false;
             $c = $textChars[$i];
-            if(!isset(self::$preprocessorChars[$c])) {
+            if (!isset(self::$preprocessorChars[$c])) {
                 // Fast exit for characters that do not start a tag.
                 // TODO Could work faster if we didn't concatenate each character
                 $parsed .= $c;
@@ -240,7 +242,7 @@ class WikitextParser
                                 /* Load wikitext of template, and preprocess it */
                                 if (self::MAX_INCLUDE_DEPTH < 0 || $depth < self::MAX_INCLUDE_DEPTH) {
                                     $markup = trim(self::$backend -> getTemplateMarkup($innerCurKey));
-                                    $parsed .= $this -> preprocessText(self::explode_string($markup), $innerArg, true, $depth + 1);
+                                    $parsed .= $this -> preprocessText(self::explodeString($markup), $innerArg, true, $depth + 1);
                                 }
                             }
 
@@ -289,10 +291,11 @@ class WikitextParser
         return $parsed;
     }
 
-    private static function tagIsAt(array $tag, array $textChars, int $position) {
+    private static function tagIsAt(array $tag, array $textChars, int $position)
+    {
         $tag_len = count($tag);
         $str_len = count($textChars);
-        if($tag_len == 0 || $position + $tag_len > $str_len || $textChars[$position] != $tag[0]) { //$textChars[$position] != $tag[0]) {
+        if ($tag_len == 0 || $position + $tag_len > $str_len || $textChars[$position] != $tag[0]) { //$textChars[$position] != $tag[0]) {
             return false;
         }
         // TODO might work faster if we can ditch use of strings
@@ -302,8 +305,9 @@ class WikitextParser
         return $len !== 0 && $tag == $text;
     }
 
-    private static function tagIsAtString(string $tag, array $textChars, int $position) {
-        $tagChars = self::explode_string($tag);
+    private static function tagIsAtString(string $tag, array $textChars, int $position)
+    {
+        $tagChars = self::explodeString($tag);
         return self::tagIsAt($tagChars, $textChars, $position);
     }
     
@@ -314,7 +318,8 @@ class WikitextParser
      * @param string $text Text to parse
      * @param $token The name of the current inline element, if inside one.
      */
-    private function parseInline(array $textChars, string $token = '') {
+    private function parseInline(array $textChars, string $token = '')
+    {
         /* Quick escape if we've run into a table */
         $inParagraph = false;
         if ($token == '' || !isset(self::$inline[$token])) {
@@ -340,7 +345,7 @@ class WikitextParser
             /* Looping through each character */
             $hit = false; // State so that the last part knows whether to simply append this as an unmatched character
             $c = $textChars[$i];
-            if(!isset(self::$inlineChars[$c])) {
+            if (!isset(self::$inlineChars[$c])) {
                 // Fast exit for characters that do not start a tag.
                 // TODO Could work faster if we didn't concatenate each character
                 $buffer .= $c;
@@ -421,7 +426,7 @@ class WikitextParser
                         $hit = true;
                         $start = $i + 1 + count(self::$tableStart -> startTag);
                         $key = 'table';
-                    } else if ($i < $len - 1){
+                    } else if ($i < $len - 1) {
                         /* Check for non-table line-based stuff coming up next, each time \n is found */
                         $next = $textChars[$i + 1];
                         foreach (self::$lineBlock as $key => $block) {
@@ -533,7 +538,7 @@ class WikitextParser
                     $endcount = self::countCharString($lineBlockElement -> endChar, strrev($line), $lineBlockElement -> limit);
                     $line = mb_substr($line, 0, mb_strlen($line) - $endcount);
                 }
-                $result = $this -> parseInline(self::explode_string($line));
+                $result = $this -> parseInline(self::explodeString($line));
                 $list[] = array('depth' => $count, 'item' => $result['parsed'], 'char' => $char);
             }
         }
@@ -544,7 +549,7 @@ class WikitextParser
         }
         $parsed = self::$backend -> renderLineBlock($token, $list);
 
-        return array('parsed' => $parsed, 'remainderChars' => self::explode_string("\n". implode("\n", $lines)));
+        return array('parsed' => $parsed, 'remainderChars' => self::explodeString("\n". implode("\n", $lines)));
     }
 
     /**
@@ -565,7 +570,7 @@ class WikitextParser
 
         while (count($lines) > 0) {
             $line = array_shift($lines);
-            $lineChars = self::explode_string($line);
+            $lineChars = self::explodeString($line);
             if (trim($line) == implode(self::$tableStart -> endTag)) {
                 /* End of table found */
                 break;
@@ -595,7 +600,7 @@ class WikitextParser
                     /* Clobber the remaining text together and throw it to the cell parser */
                     $line = implode($lineChars);
                     array_unshift($lines, $line);
-                    $remainderChars = self::explode_string(implode("\n", $lines));
+                    $remainderChars = self::explodeString(implode("\n", $lines));
                     $result = $this -> parseTableCells($token, $remainderChars, $tmpRow['col']);
                     $lines = explode("\n", implode($result['remainderChars']));
                     $tmpRow['col'] = $result['col'];
@@ -619,7 +624,7 @@ class WikitextParser
         }
 
         $parsed = self::$backend -> renderTable($table);
-        return array('parsed' => $parsed, 'remainderChars' => self::explode_string("\n". implode("\n", $lines)));
+        return array('parsed' => $parsed, 'remainderChars' => self::explodeString("\n". implode("\n", $lines)));
     }
 
     /**

--- a/src/Mike42/Wikitext/WikitextParser.php
+++ b/src/Mike42/Wikitext/WikitextParser.php
@@ -184,7 +184,7 @@ class WikitextParser
             $hit = false;
             $c = $textChars[$i];
             if (!isset(self::$preprocessorChars[$c])) {
-                // Fast exit for characters that do not start a tag.
+                /* Fast exit for characters that do not start a tag. */
                 // TODO Could work faster if we didn't concatenate each character
                 $parsed .= $c;
                 continue;
@@ -204,7 +204,7 @@ class WikitextParser
                     /* Hit a symbol. Parse it and keep going after the result */
                     $hit = true;
                     $i += count($child -> startTag);
-                        
+
                     if (($key == 'includeonly' && $included) || ($key == 'noinclude' && !$included)) {
                         /* If this is a good tag, ignore it! */
                         break;
@@ -214,7 +214,7 @@ class WikitextParser
                     $innerArg   = [];
                     $innerBuffer = '';
                     $innerCurKey = '';
-                        
+
                     for ($i = $i; $i < $len; $i++) {
                         $innerHit = false;
 
@@ -309,7 +309,7 @@ class WikitextParser
         }
         return $match;
     }
-    
+
     /**
      * Parse a block of wikitext looking for inline tokens, indicating the start of an element.
      * Calls itself recursively to search inside those elements when it finds them
@@ -331,14 +331,14 @@ class WikitextParser
         } else {
             $inlineElement = self::$inline[$token];
         }
-        
+
         $parsed = ''; // For completely parsed text
         $buffer = ''; // For text which may still be encapsulated or chopped up
         $remainder = '';
-        
+
         $arg = [];
         $curKey = '';
-        
+
         $len = count($textChars);
         for ($i = $idxFrom; $i < $len; $i++) {
             /* Looping through each character */
@@ -350,8 +350,7 @@ class WikitextParser
                 $buffer .= $c;
                 continue;
             }
-            
-            
+
             /* Looking for this element's close-token */
             if (self::tagIsAt($inlineElement -> endTag, $textChars, $i)) {
                 /* Hit a close tag: Stop parsing here, return the remainder, and let the parent continue */
@@ -366,12 +365,12 @@ class WikitextParser
                     }
                     $buffer = self::$backend -> renderWithArgs($token, $arg);
                 }
-                
+
                 /* Clean up and quit */
                 $parsed .= $buffer; /* As far as I can tall $inPargraph should always be false here? */
                 return array('parsed' => $parsed, 'remainderIdx' => $start);
             }
-            
+
             /* Next priority is looking for this element's agument tokens if applicable */
             if ($inlineElement -> hasArgs && ($inlineElement -> argLimit == 0 || $inlineElement -> argLimit > count($arg))) {
                 if (self::tagIsAt($inlineElement -> argSep, $textChars, $i)) {
@@ -381,7 +380,7 @@ class WikitextParser
                     } else {
                         $arg[$curKey] = $buffer;
                     }
-                    
+
                     $curKey = ''; // Reset key
                     $buffer = ''; // Reset parsed values
                     /* Handle position properly */
@@ -502,14 +501,15 @@ class WikitextParser
         /* Block element we are using */
         $lineBlockElement = self::$lineBlock[$token];
         
-        // Attempted re-write
+        // Loop through lines
         $lineStart = $fromIdx;
         $list = [];
         while (($lineLen = self::getLineLen($textChars, $lineStart)) !== false) {
             $startTokenLen = self::countChar($lineBlockElement -> startChar, $textChars, $lineStart, $lineBlockElement -> limit);
             if ($startTokenLen === 0) {
-                // Wind back to include "\n" if the next line is not a list item. This is not expected
-                // to trigger on the first iteration, since line-block tags were found for calling this method.
+                /* Wind back to include "\n" if the next line is not a list item. This is not expected
+                 * to trigger on the first iteration, since line-block tags were found for calling this method.
+                 */
                 $lineStart -= 1;
                 break;
             } else {
@@ -519,12 +519,12 @@ class WikitextParser
                     /* Also need to cut off end letters, such as in == Heading == */
                     $endTokenLen = self::countCharReverse($lineBlockElement -> endChar, $textChars, $lineStart + $startTokenLen, $lineStart + $lineLen - 1);
                 }
-                // Remainder of the line
+                /* Remainder of the line */
                 $lineChars = array_slice($textChars, $lineStart + $startTokenLen, $lineLen - $startTokenLen - $endTokenLen);
                 $result = $this -> parseInline($lineChars);
                 $list[] = array('depth' => $startTokenLen, 'item' => $result['parsed'], 'char' => $char);
             }
-            // Move along to start of next line
+            /* Move along to start of next line */
             $lineStart += $lineLen + 1;
         }
 
@@ -567,7 +567,7 @@ class WikitextParser
                 $tokenLen = count($block -> lineStart);
                 $contentStart = $lineStart + $tokenLen;
                 $contentLen = $lineLen - $tokenLen;
-                
+
                 if ($token == 'td' || $token == 'th') {
                     if (!isset($tmpRow)) {
                         /* Been given a cell before a row. Make a row first */
@@ -591,7 +591,7 @@ class WikitextParser
                     );
                 }
             }
-            // Move along to start of next line
+            /* Move along to start of next line */
             $lineStart += $lineLen + 1;
         }
         if (isset($tmpRow)) {
@@ -601,10 +601,10 @@ class WikitextParser
         $parsed = self::$backend -> renderTable($table);
         return array('parsed' => $parsed, 'remainderIdx' => $lineStart);
     }
-    
+
     private static function getLineLen(array $textChars, int $position)
     {
-        // Return number of characters in line, or FALSE if the string is depleted
+        /* Return number of characters in line, or FALSE if the string is depleted */
         for ($i = $position; $i < count($textChars); $i++) {
             if ($textChars[$i] == "\n") {
                 return $i - $position;
@@ -660,16 +660,16 @@ class WikitextParser
                     }
                 }
             }
-                
+
             if ($hit) {
                 /* Parse whatever it is and return here */
                 $start = $i;
                 $result = $this -> parseInline($textChars, 'td', $start);
                 $buffer .= $result['parsed'];
-                // TODO was -1 before
+                // TODO was -1 before, seems to work well though
                 $i = $result['remainderIdx'];
             }
-                
+
             if (!$hit && self::tagIsAt($tableElement -> inlinesep, $textChars, $i)) {
                 /* Got column separator, so this column is now finished */
                 $tmpCol['content'] = $buffer;
@@ -682,7 +682,7 @@ class WikitextParser
                 $i += count($tableElement -> inlinesep) - 1;
                 $argCount = 0;
             }
-                
+
             if (!$hit && $argCount < ($tableElement -> limit) && self::tagIsAt($tableElement -> argsep, $textChars, $i)) {
                 /* Got argument separator. Shift off the last argument */
                 $tmpCol['arg'][] = $buffer;
@@ -691,7 +691,7 @@ class WikitextParser
                 $i += count($tableElement -> argsep) - 1;
                 $argCount++;
             }
-                
+
             if (!$hit) {
                 $c = $textChars[$i];
                 if ($c == "\n") {
@@ -730,7 +730,7 @@ class WikitextParser
         }
         return $i;
     }
-    
+
     /**
      * Create a list from what we found in parseLineBlock(), returning all elements.
      */


### PR DESCRIPTION
This pull request makes a significant performance improvement to the parser.

Average execution time over 10 runs for the `Images` example (39kb of wikitext).

- Before: 20.65 seconds
- After: 0.145 seconds

The speedup is around 142 x.

The output of some buggy code has changed slightly, but no correct output was harmed in the making of this code.